### PR TITLE
Update jlesc.bib

### DIFF
--- a/_bibliography/jlesc.bib
+++ b/_bibliography/jlesc.bib
@@ -1809,3 +1809,13 @@ year = {2024}
   HAL_VERSION = {v1},
 }
 
+@article{HascoetEtAl2025,
+  title = {HFBTHO-AD: Differentiation of a nuclear energy density functional code},
+  journal = {Computer Physics Communications},
+  volume = {320},
+  pages = {109955},
+  year = {2026},
+  issn = {0010-4655},
+  doi = {https://doi.org/10.1016/j.cpc.2025.109955},
+  author = {Laurent Hascoët and Matt Menickelly and Sri Hari Krishna Narayanan and Jared O’Neal and   Nicolas Schunck and Stefan M. Wild},
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adds a single BibTeX entry and does not affect application logic or security-sensitive behavior.
> 
> **Overview**
> Adds a new `@article{HascoetEtAl2025}` BibTeX entry to `jlesc.bib` for the *Computer Physics Communications* paper “HFBTHO-AD: Differentiation of a nuclear energy density functional code” (year 2026), including DOI/ISSN/volume/pages and author list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43172df545be53d0e6390b0ca48b4330ba84c3fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->